### PR TITLE
Job event broadcasting + Orchestrator Improvements

### DIFF
--- a/src/backend/endpoints.py
+++ b/src/backend/endpoints.py
@@ -1278,17 +1278,17 @@ async def validator_websocket(websocket: WebSocket):
                         # Create evaluation completed event
                         # Pydantic will automatically handle datetime to ISO conversion
                         eval_event = EvaluationCompletedEvent(
-                            job_id=result.job_id,
-                            validator_hotkey=result.validator_hotkey,
-                            miner_hotkey=result.miner_hotkey,
-                            competition_id=result.competition_id,
-                            benchmark_name=result.benchmark_name,
-                            score=result.score,
-                            success_rate=result.success_rate,
-                            avg_reward=result.avg_reward,
-                            total_episodes=result.total_episodes,
-                            result_time=result.result_time,
-                            created_at=result.created_at,
+                            job_id=eval_result.job_id,
+                            validator_hotkey=eval_result.validator_hotkey,
+                            miner_hotkey=eval_result.miner_hotkey,
+                            competition_id=eval_result.competition_id,
+                            benchmark_name=eval_result.benchmark,
+                            score=eval_result.score,
+                            success_rate=eval_result.success_rate,
+                            avg_reward=eval_result.avg_reward,
+                            total_episodes=eval_result.total_episodes,
+                            result_time=eval_result.result_time,
+                            created_at=eval_result.created_at,
                         )
                         await event_broadcaster.broadcast_event(
                             EventType.EVALUATION_COMPLETED, eval_event

--- a/src/backend/endpoints.py
+++ b/src/backend/endpoints.py
@@ -1169,6 +1169,9 @@ async def validator_websocket(websocket: WebSocket):
         )
         await event_broadcaster.broadcast_event(EventType.VALIDATOR_CONNECTED, event)
 
+        # Broadcast updated stats (validator count changed)
+        await backend_service._broadcast_stats_update()
+
         # Handle messages
         while True:
             data = await websocket.receive_text()
@@ -1352,6 +1355,7 @@ async def validator_websocket(websocket: WebSocket):
                         if isinstance(episode_msg.end_time, datetime)
                         else datetime.fromisoformat(episode_msg.end_time),
                         extra_metrics=episode_msg.extra_metrics,
+                        created_at=datetime.now(timezone.utc),
                     )
                     await event_broadcaster.broadcast_event(
                         EventType.EPISODE_COMPLETED, episode_event
@@ -1482,6 +1486,9 @@ async def validator_websocket(websocket: WebSocket):
             await event_broadcaster.broadcast_event(
                 EventType.VALIDATOR_DISCONNECTED, disconnected_event
             )
+
+            # Broadcast updated stats (validator count changed)
+            await backend_service._broadcast_stats_update()
 
 
 # ============================================================================

--- a/src/backend/events.py
+++ b/src/backend/events.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
+from core.db.models import EvaluationStatus
+
 
 class BaseEvent(BaseModel):
     """Base class for all event data models."""
@@ -22,11 +24,6 @@ class BaseEvent(BaseModel):
     )
 
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-
-    @field_serializer("timestamp", when_used="json")
-    def serialize_timestamp(self, timestamp: datetime) -> str:
-        """Serialize timestamp to ISO format string."""
-        return timestamp.isoformat()
 
     @field_serializer("*", mode="wrap")
     def serialize_datetime_fields(self, value, serializer, info):
@@ -76,7 +73,7 @@ class JobStatusChangedEvent(JobEventMixin, BaseEvent):
     """Event data for JOB_STATUS_CHANGED event."""
 
     validator_hotkey: str
-    status: str
+    status: EvaluationStatus
     detail: Optional[str] = None
     created_at: datetime
 
@@ -85,7 +82,7 @@ class JobCompletedEvent(JobEventMixin, BaseEvent):
     """Event data for JOB_COMPLETED event."""
 
     validator_hotkey: str
-    status: str
+    status: EvaluationStatus
     detail: Optional[str] = None
     result_count: int = 0
 

--- a/src/backend/events.py
+++ b/src/backend/events.py
@@ -40,8 +40,7 @@ class BaseEvent(BaseModel):
 class JobCreatedEvent(BaseEvent):
     """Event data for JOB_CREATED event."""
 
-    job_id: str
-    validator_hotkey: str
+    job_id: int
     competition_id: str
     submission_id: int
     miner_hotkey: str
@@ -54,7 +53,7 @@ class JobCreatedEvent(BaseEvent):
 class JobStatusChangedEvent(BaseEvent):
     """Event data for JOB_STATUS_CHANGED event."""
 
-    job_id: str
+    job_id: int
     validator_hotkey: str
     status: str
     detail: Optional[str] = None
@@ -64,7 +63,7 @@ class JobStatusChangedEvent(BaseEvent):
 class JobCompletedEvent(BaseEvent):
     """Event data for JOB_COMPLETED event."""
 
-    job_id: str
+    job_id: int
     validator_hotkey: str
     status: str
     detail: Optional[str] = None
@@ -75,7 +74,7 @@ class JobCompletedEvent(BaseEvent):
 class EvaluationStartedEvent(BaseEvent):
     """Event data for EVALUATION_STARTED event."""
 
-    job_id: str
+    job_id: int
     validator_hotkey: str
     miner_hotkey: str
     competition_id: str
@@ -86,7 +85,7 @@ class EvaluationStartedEvent(BaseEvent):
 class EvaluationProgressEvent(BaseEvent):
     """Event data for EVALUATION_PROGRESS event."""
 
-    job_id: str
+    job_id: int
     validator_hotkey: str
     miner_hotkey: str
     competition_id: str
@@ -99,7 +98,7 @@ class EvaluationProgressEvent(BaseEvent):
 class EvaluationCompletedEvent(BaseEvent):
     """Event data for EVALUATION_COMPLETED event."""
 
-    job_id: str
+    job_id: int
     validator_hotkey: str
     miner_hotkey: str
     competition_id: str
@@ -116,8 +115,8 @@ class EvaluationCompletedEvent(BaseEvent):
 class EpisodeStartedEvent(BaseEvent):
     """Event data for EPISODE_STARTED event."""
 
-    job_id: str
-    submission_id: str
+    job_id: int
+    submission_id: int
     episode_id: int
     env_name: str
     benchmark_name: str
@@ -126,7 +125,7 @@ class EpisodeStartedEvent(BaseEvent):
 class EpisodeStepEvent(BaseEvent):
     """Event data for EPISODE_STEP event."""
 
-    submission_id: str
+    submission_id: int
     episode_id: int
     step: int
     action: Dict[str, Any]
@@ -140,8 +139,8 @@ class EpisodeStepEvent(BaseEvent):
 class EpisodeCompletedEvent(BaseEvent):
     """Event data for EPISODE_COMPLETED event."""
 
-    job_id: str
-    submission_id: str
+    job_id: int
+    submission_id: int
     episode_id: int
     env_name: str
     benchmark_name: str
@@ -241,5 +240,7 @@ class StatsUpdatedEvent(BaseEvent):
     total_submissions: int
     total_jobs: int
     total_results: int
+    completed_jobs: int
+    failed_jobs: int
     last_seen_block: int
     competition_percentages: Dict[str, float]

--- a/src/backend/events.py
+++ b/src/backend/events.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
+from backend.models import SS58Address
 from core.db.models import EvaluationStatus
 
 
@@ -146,6 +147,7 @@ class EpisodeStepEvent(SubmissionEventMixin, BaseEvent):
     truncated: bool
     observation_refs: Dict[str, Any]
     info: Optional[Dict[str, Any]] = None
+    validator_hotkey: Optional[SS58Address] = None
 
 
 class EpisodeCompletedEvent(JobEventMixin, SubmissionEventMixin, BaseEvent):
@@ -161,6 +163,7 @@ class EpisodeCompletedEvent(JobEventMixin, SubmissionEventMixin, BaseEvent):
     end_time: datetime
     extra_metrics: Optional[Dict[str, Any]] = None
     created_at: datetime
+    validator_hotkey: Optional[SS58Address] = None
 
 
 # Competition Events

--- a/src/backend/events.py
+++ b/src/backend/events.py
@@ -68,6 +68,7 @@ class JobCreatedEvent(JobEventMixin, SubmissionEventMixin, BaseEvent):
     benchmark_name: str
     config: Dict[str, Any]
     status: EvaluationStatus
+    validator_statuses: Dict[str, EvaluationStatus] = Field(default_factory=dict)
 
 
 class JobStatusChangedEvent(JobEventMixin, BaseEvent):

--- a/src/backend/events.py
+++ b/src/backend/events.py
@@ -67,6 +67,7 @@ class JobCreatedEvent(JobEventMixin, SubmissionEventMixin, BaseEvent):
     env_provider: str
     benchmark_name: str
     config: Dict[str, Any]
+    status: EvaluationStatus
 
 
 class JobStatusChangedEvent(JobEventMixin, BaseEvent):

--- a/src/backend/events.py
+++ b/src/backend/events.py
@@ -58,6 +58,18 @@ class SubmissionEventMixin(BaseModel):
         return str(v)
 
 
+class EpisodeEventMixin(BaseModel):
+    """Mixin for events that include an episode_id field."""
+
+    episode_id: str
+
+    @field_validator("episode_id", mode="before")
+    @classmethod
+    def convert_episode_id_to_string(cls, v: Union[int, str]) -> str:
+        """Convert episode_id to string if it's an integer."""
+        return str(v)
+
+
 # Job Events
 class JobCreatedEvent(JobEventMixin, SubmissionEventMixin, BaseEvent):
     """Event data for JOB_CREATED event."""
@@ -128,18 +140,18 @@ class EvaluationCompletedEvent(JobEventMixin, BaseEvent):
 
 
 # Episode Events
-class EpisodeStartedEvent(JobEventMixin, SubmissionEventMixin, BaseEvent):
+class EpisodeStartedEvent(
+    JobEventMixin, SubmissionEventMixin, EpisodeEventMixin, BaseEvent
+):
     """Event data for EPISODE_STARTED event."""
 
-    episode_id: int
     env_name: str
     benchmark_name: str
 
 
-class EpisodeStepEvent(SubmissionEventMixin, BaseEvent):
+class EpisodeStepEvent(SubmissionEventMixin, EpisodeEventMixin, BaseEvent):
     """Event data for EPISODE_STEP event."""
 
-    episode_id: int
     step: int
     action: Dict[str, Any]
     reward: float
@@ -150,13 +162,14 @@ class EpisodeStepEvent(SubmissionEventMixin, BaseEvent):
     validator_hotkey: Optional[SS58Address] = None
 
 
-class EpisodeCompletedEvent(JobEventMixin, SubmissionEventMixin, BaseEvent):
+class EpisodeCompletedEvent(
+    JobEventMixin, SubmissionEventMixin, EpisodeEventMixin, BaseEvent
+):
     """Event data for EPISODE_COMPLETED event."""
 
-    episode_id: int
     env_name: str
     benchmark_name: str
-    total_reward: float
+    final_reward: float
     success: bool
     steps: int
     start_time: datetime

--- a/src/backend/migrations/versions/002_add_episode_logging_tables.py
+++ b/src/backend/migrations/versions/002_add_episode_logging_tables.py
@@ -28,7 +28,7 @@ def upgrade() -> None:
         sa.Column("episode_id", sa.Integer(), nullable=False),
         sa.Column("env_name", sa.String(length=128), nullable=False),
         sa.Column("benchmark_name", sa.String(length=128), nullable=False),
-        sa.Column("total_reward", sa.Float(), nullable=False),
+        sa.Column("final_reward", sa.Float(), nullable=False),
         sa.Column("success", sa.Boolean(), nullable=False),
         sa.Column("steps", sa.Integer(), nullable=False),
         sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),

--- a/src/backend/migrations/versions/008_add_validator_hotkeys_to_episode_tables.py
+++ b/src/backend/migrations/versions/008_add_validator_hotkeys_to_episode_tables.py
@@ -1,0 +1,48 @@
+"""Add validator hotkeys to episode tables
+
+Revision ID: 008_validator_hotkeys_episode
+Revises: 007_add_api_key_to_validators
+Create Date: 2025-01-08 00:03:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "008_validator_hotkeys_episode"
+down_revision: Union[str, None] = "007_add_api_key_to_validators"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "episode_data",
+        sa.Column("validator_hotkey", sa.String(length=48), nullable=True),
+    )
+    op.add_column(
+        "episode_step_data",
+        sa.Column("validator_hotkey", sa.String(length=48), nullable=True),
+    )
+
+    op.create_index(
+        "ix_episode_data_validator",
+        "episode_data",
+        ["validator_hotkey"],
+    )
+    op.create_index(
+        "ix_episode_step_validator",
+        "episode_step_data",
+        ["validator_hotkey"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_episode_step_validator", table_name="episode_step_data")
+    op.drop_index("ix_episode_data_validator", table_name="episode_data")
+
+    op.drop_column("episode_step_data", "validator_hotkey")
+    op.drop_column("episode_data", "validator_hotkey")

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -510,6 +510,10 @@ class EpisodeData(TimestampMixin, SQLModel, table=True):
         )
     )
     submission_id: str = Field(max_length=128, nullable=False, index=True)
+    validator_hotkey: Optional[SS58Address] = Field(
+        default=None,
+        sa_column=Column(SAString(48), nullable=True),
+    )
 
     # Episode metadata
     task_id: str = Field(max_length=128, nullable=False, index=True)
@@ -546,6 +550,7 @@ class EpisodeData(TimestampMixin, SQLModel, table=True):
         Index("ix_episode_data_episode", "episode_id"),
         Index("ix_episode_data_success", "success"),
         Index("ix_episode_data_submission_task", "submission_id", "task_id"),
+        Index("ix_episode_data_validator", "validator_hotkey"),
     )
 
 
@@ -566,6 +571,10 @@ class EpisodeStepData(TimestampMixin, SQLModel, table=True):
         )
     )
     submission_id: str = Field(max_length=128, nullable=False, index=True)
+    validator_hotkey: Optional[SS58Address] = Field(
+        default=None,
+        sa_column=Column(SAString(48), nullable=True),
+    )
 
     # Step metadata
     task_id: str = Field(max_length=128, nullable=False, index=True)
@@ -601,6 +610,7 @@ class EpisodeStepData(TimestampMixin, SQLModel, table=True):
         Index("ix_episode_step_submission", "submission_id"),
         Index("ix_episode_step_task", "task_id"),
         Index("ix_episode_step_step", "step"),
+        Index("ix_episode_step_validator", "validator_hotkey"),
         UniqueConstraint(
             "episode_id", "step", name="uq_episode_step"
         ),  # Ensure unique steps per episode

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.sql import func
 from sqlmodel import JSON, Column, Field, Relationship, SQLModel
+from pydantic import field_validator
 
 from backend.constants import (
     DEFAULT_MIN_AVG_REWARD,
@@ -80,7 +81,7 @@ class ValidatorInfoResponse(SQLModel):
 
     validator_hotkey: str
     connection_id: str
-    api_key_id: Optional[SnowflakeId]
+    api_key_id: Optional[str]
     is_connected: bool
     first_connected_at: datetime
     last_heartbeat: datetime
@@ -91,11 +92,16 @@ class ValidatorInfoResponse(SQLModel):
     class Config:
         from_attributes = True
 
+    @field_validator("api_key_id", mode="before")
+    @classmethod
+    def _convert_api_key_id(cls, value):
+        return None if value is None else str(value)
+
 
 class MinerSubmissionResponse(SQLModel):
     """Response model for miner submission data."""
 
-    id: SnowflakeId
+    id: str
     miner_hotkey: str
     competition_id: str
     hf_repo_id: str
@@ -107,12 +113,17 @@ class MinerSubmissionResponse(SQLModel):
     class Config:
         from_attributes = True
 
+    @field_validator("id", mode="before")
+    @classmethod
+    def _convert_id(cls, value):
+        return str(value)
+
 
 class JobResponse(SQLModel):
     """Response model for job data."""
 
-    id: SnowflakeId
-    submission_id: int
+    id: str
+    submission_id: str
     competition_id: str
     miner_hotkey: str
     hf_repo_id: str
@@ -124,12 +135,17 @@ class JobResponse(SQLModel):
     class Config:
         from_attributes = True
 
+    @field_validator("id", "submission_id", mode="before")
+    @classmethod
+    def _convert_ids(cls, value):
+        return str(value)
+
 
 class EvaluationResultResponse(SQLModel):
     """Response model for evaluation result data."""
 
-    id: SnowflakeId
-    job_id: SnowflakeId
+    id: str
+    job_id: str
     validator_hotkey: str
     miner_hotkey: str
     competition_id: str
@@ -144,12 +160,17 @@ class EvaluationResultResponse(SQLModel):
     class Config:
         from_attributes = True
 
+    @field_validator("id", "job_id", mode="before")
+    @classmethod
+    def _convert_ids(cls, value):
+        return str(value)
+
 
 class JobStatusResponse(SQLModel):
     """Response model for job status data."""
 
-    id: SnowflakeId
-    job_id: SnowflakeId
+    id: str
+    job_id: str
     validator_hotkey: str
     status: EvaluationStatus
     detail: Optional[str]
@@ -158,6 +179,11 @@ class JobStatusResponse(SQLModel):
 
     class Config:
         from_attributes = True
+
+    @field_validator("id", "job_id", mode="before")
+    @classmethod
+    def _convert_ids(cls, value):
+        return str(value)
 
 
 class BackendStatsResponse(SQLModel):
@@ -187,7 +213,7 @@ class ApiKeyCreateRequest(SQLModel):
 class ApiKeyResponse(SQLModel):
     """Response model for API key data (without the actual key)."""
 
-    id: SnowflakeId
+    id: str
     name: str
     description: Optional[str]
     role: str
@@ -201,11 +227,16 @@ class ApiKeyResponse(SQLModel):
     class Config:
         from_attributes = True
 
+    @field_validator("id", mode="before")
+    @classmethod
+    def _convert_id(cls, value):
+        return str(value)
+
 
 class ApiKeyCreateResponse(SQLModel):
     """Response model for API key creation (includes the actual key)."""
 
-    id: SnowflakeId
+    id: str
     name: str
     description: Optional[str]
     role: str
@@ -217,6 +248,11 @@ class ApiKeyCreateResponse(SQLModel):
 
     class Config:
         from_attributes = True
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def _convert_id(cls, value):
+        return str(value)
 
 
 # Models for DB tables
@@ -522,7 +558,7 @@ class EpisodeData(TimestampMixin, SQLModel, table=True):
     benchmark_name: str = Field(max_length=128, nullable=False)
 
     # Episode results
-    total_reward: float = Field(nullable=False)
+    final_reward: float = Field(nullable=False)
     success: bool = Field(nullable=False, index=True)
     steps: int = Field(nullable=False)
 

--- a/src/backend/realtime.py
+++ b/src/backend/realtime.py
@@ -1072,7 +1072,7 @@ class RealtimeEventBroadcaster:
                     episode_id=episode.episode_id,
                     env_name=episode.env_name,
                     benchmark_name=episode.benchmark_name,
-                    total_reward=episode.total_reward,
+                    final_reward=episode.final_reward,
                     success=episode.success,
                     steps=episode.steps,
                     start_time=episode.start_time or datetime.now(timezone.utc),

--- a/src/backend/realtime.py
+++ b/src/backend/realtime.py
@@ -1052,6 +1052,10 @@ class RealtimeEventBroadcaster:
                         query = query.where(EpisodeData.submission_id == filter_value)
                     elif filter_key == "episode_id":
                         query = query.where(EpisodeData.episode_id == filter_value)
+                    elif filter_key == "validator_hotkey":
+                        query = query.where(
+                            EpisodeData.validator_hotkey == filter_value
+                        )
 
             query = query.order_by(EpisodeData.created_at.desc()).limit(limit)
 
@@ -1064,6 +1068,7 @@ class RealtimeEventBroadcaster:
                 event = EpisodeCompletedEvent(
                     job_id=str(episode.job_id),
                     submission_id=str(episode.submission_id),
+                    validator_hotkey=episode.validator_hotkey,
                     episode_id=episode.episode_id,
                     env_name=episode.env_name,
                     benchmark_name=episode.benchmark_name,

--- a/src/backend/realtime.py
+++ b/src/backend/realtime.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from fastapi import WebSocket
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 
 from backend.constants import INITIAL_STATE_DATA_LIMIT
 from backend.events import (
@@ -21,6 +21,8 @@ from backend.events import (
     CompetitionCreatedEvent,
     EpisodeCompletedEvent,
     EvaluationCompletedEvent,
+    JobCompletedEvent,
+    JobCreatedEvent,
     JobStatusChangedEvent,
     StatsUpdatedEvent,
     SubmissionReceivedEvent,
@@ -54,6 +56,7 @@ try:
         MinerSubmission,
         ValidatorConnection,
     )
+    from core.db.models import EvaluationStatus
 except ImportError:
     # Handle case where models might not be available during testing
     pass
@@ -409,12 +412,12 @@ class RealtimeEventBroadcaster:
                 return await self._get_initial_stats_data(session)
 
             # Job-related events
-            elif event_type in [
-                EventType.JOB_STATUS_CHANGED,
-                EventType.JOB_CREATED,
-                EventType.JOB_COMPLETED,
-            ]:
-                return await self._get_initial_job_data(session, filters)
+            elif event_type == EventType.JOB_CREATED:
+                return await self._get_initial_job_created_data(session, filters)
+            elif event_type == EventType.JOB_STATUS_CHANGED:
+                return await self._get_initial_job_status_data(session, filters)
+            elif event_type == EventType.JOB_COMPLETED:
+                return await self._get_initial_job_completed_data(session, filters)
 
             # Evaluation-related events
             elif event_type in [
@@ -441,9 +444,12 @@ class RealtimeEventBroadcaster:
             elif event_type in [EventType.EPISODE_COMPLETED, EventType.EPISODE_STARTED]:
                 return await self._get_initial_episode_data(session, filters)
 
+            # Validator events
+            elif event_type == EventType.VALIDATOR_CONNECTED:
+                return await self._get_initial_validator_data(session, filters)
+
             # Skip these events - either not suitable for initial data or too granular
             elif event_type in [
-                EventType.VALIDATOR_CONNECTED,
                 EventType.VALIDATOR_DISCONNECTED,
                 EventType.EPISODE_STEP,
             ]:
@@ -487,6 +493,67 @@ class RealtimeEventBroadcaster:
             )
             total_jobs = job_result.scalar() or 0
 
+            # Get completed jobs count (latest status is COMPLETED)
+            latest_status_subquery = (
+                select(
+                    BackendEvaluationJobStatus.job_id,
+                    func.max(BackendEvaluationJobStatus.created_at).label(
+                        "max_created_at"
+                    ),
+                )
+                .group_by(BackendEvaluationJobStatus.job_id)
+                .subquery()
+            )
+
+            completed_jobs_result = await session.execute(
+                select(func.count(BackendEvaluationJob.id.distinct()))
+                .select_from(BackendEvaluationJob)
+                .join(
+                    BackendEvaluationJobStatus,
+                    BackendEvaluationJob.id == BackendEvaluationJobStatus.job_id,
+                )
+                .join(
+                    latest_status_subquery,
+                    and_(
+                        BackendEvaluationJobStatus.job_id
+                        == latest_status_subquery.c.job_id,
+                        BackendEvaluationJobStatus.created_at
+                        == latest_status_subquery.c.max_created_at,
+                    ),
+                )
+                .where(BackendEvaluationJobStatus.status == EvaluationStatus.COMPLETED)
+            )
+            completed_jobs = completed_jobs_result.scalar() or 0
+
+            # Get failed jobs count (latest status is FAILED, CANCELLED, or TIMEOUT)
+            failed_jobs_result = await session.execute(
+                select(func.count(BackendEvaluationJob.id.distinct()))
+                .select_from(BackendEvaluationJob)
+                .join(
+                    BackendEvaluationJobStatus,
+                    BackendEvaluationJob.id == BackendEvaluationJobStatus.job_id,
+                )
+                .join(
+                    latest_status_subquery,
+                    and_(
+                        BackendEvaluationJobStatus.job_id
+                        == latest_status_subquery.c.job_id,
+                        BackendEvaluationJobStatus.created_at
+                        == latest_status_subquery.c.max_created_at,
+                    ),
+                )
+                .where(
+                    BackendEvaluationJobStatus.status.in_(
+                        [
+                            EvaluationStatus.FAILED,
+                            EvaluationStatus.CANCELLED,
+                            EvaluationStatus.TIMEOUT,
+                        ]
+                    )
+                )
+            )
+            failed_jobs = failed_jobs_result.scalar() or 0
+
             # Get results count
             result_count = await session.execute(
                 select(func.count(BackendEvaluationResult.id))
@@ -516,6 +583,8 @@ class RealtimeEventBroadcaster:
                 total_submissions=total_submissions,
                 total_jobs=total_jobs,
                 total_results=total_results,
+                completed_jobs=completed_jobs,
+                failed_jobs=failed_jobs,
                 last_seen_block=state.last_seen_block if state else 0,
                 competition_percentages=comp_percentages,
             )
@@ -565,13 +634,98 @@ class RealtimeEventBroadcaster:
             logger.error(f"Error getting initial validator data: {str(e)}")
             return []
 
-    async def _get_initial_job_data(
+    async def _get_initial_job_created_data(
         self, session, filters: Dict[str, Any], limit: int = INITIAL_STATE_DATA_LIMIT
     ) -> List[Dict[str, Any]]:
-        """Get recent job status data."""
+        """Get jobs that are currently queued or running (for JOB_CREATED subscriptions)."""
         try:
-            # BackendEvaluationJobStatus is imported at module level
+            # Find jobs with active statuses (QUEUED, STARTING, RUNNING)
+            # We need to get the latest status for each job and filter by those statuses
 
+            # Get all jobs with their latest status
+            latest_status_subquery = (
+                select(
+                    BackendEvaluationJobStatus.job_id,
+                    func.max(BackendEvaluationJobStatus.created_at).label(
+                        "max_created_at"
+                    ),
+                )
+                .group_by(BackendEvaluationJobStatus.job_id)
+                .subquery()
+            )
+
+            # Join to get jobs with active statuses
+            query = (
+                select(BackendEvaluationJob)
+                .join(
+                    BackendEvaluationJobStatus,
+                    BackendEvaluationJob.id == BackendEvaluationJobStatus.job_id,
+                )
+                .join(
+                    latest_status_subquery,
+                    and_(
+                        BackendEvaluationJobStatus.job_id
+                        == latest_status_subquery.c.job_id,
+                        BackendEvaluationJobStatus.created_at
+                        == latest_status_subquery.c.max_created_at,
+                    ),
+                )
+                .where(
+                    BackendEvaluationJobStatus.status.in_(
+                        [
+                            EvaluationStatus.QUEUED,
+                            EvaluationStatus.STARTING,
+                            EvaluationStatus.RUNNING,
+                        ]
+                    )
+                )
+            )
+
+            # Apply filters if any
+            if filters:
+                for filter_key, filter_value in filters.items():
+                    if filter_key == "job_id":
+                        query = query.where(BackendEvaluationJob.id == filter_value)
+                    elif filter_key == "competition_id":
+                        query = query.where(
+                            BackendEvaluationJob.competition_id == filter_value
+                        )
+                    elif filter_key == "miner_hotkey":
+                        query = query.where(
+                            BackendEvaluationJob.miner_hotkey == filter_value
+                        )
+
+            query = query.order_by(BackendEvaluationJob.created_at.desc()).limit(limit)
+
+            result = await session.execute(query)
+            jobs = result.scalars().all()
+
+            job_data = []
+            for job in jobs:
+                # Use JobCreatedEvent model to match the event structure
+                event = JobCreatedEvent(
+                    job_id=job.id,
+                    competition_id=job.competition_id,
+                    submission_id=job.submission_id,
+                    miner_hotkey=job.miner_hotkey,
+                    hf_repo_id=job.hf_repo_id,
+                    env_provider=job.env_provider,
+                    benchmark_name=job.benchmark_name,
+                    config=job.config if job.config else {},
+                )
+                job_data.append(event.model_dump(mode="json"))
+
+            return job_data
+
+        except Exception as e:
+            logger.error(f"Error getting initial job created data: {str(e)}")
+            return []
+
+    async def _get_initial_job_status_data(
+        self, session, filters: Dict[str, Any], limit: int = INITIAL_STATE_DATA_LIMIT
+    ) -> List[Dict[str, Any]]:
+        """Get recent job status changes (for JOB_STATUS_CHANGED subscriptions)."""
+        try:
             query = select(BackendEvaluationJobStatus)
 
             # Apply filters if any
@@ -608,7 +762,87 @@ class RealtimeEventBroadcaster:
             return job_data
 
         except Exception as e:
-            logger.error(f"Error getting initial job data: {str(e)}")
+            logger.error(f"Error getting initial job status data: {str(e)}")
+            return []
+
+    async def _get_initial_job_completed_data(
+        self, session, filters: Dict[str, Any], limit: int = INITIAL_STATE_DATA_LIMIT
+    ) -> List[Dict[str, Any]]:
+        """Get recently completed jobs (for JOB_COMPLETED subscriptions)."""
+        try:
+            # Find jobs that have completed status
+            latest_status_subquery = (
+                select(
+                    BackendEvaluationJobStatus.job_id,
+                    func.max(BackendEvaluationJobStatus.created_at).label(
+                        "max_created_at"
+                    ),
+                )
+                .group_by(BackendEvaluationJobStatus.job_id)
+                .subquery()
+            )
+
+            # Join to get jobs with completed/failed/cancelled/timeout statuses
+            query = (
+                select(BackendEvaluationJob, BackendEvaluationJobStatus)
+                .join(
+                    BackendEvaluationJobStatus,
+                    BackendEvaluationJob.id == BackendEvaluationJobStatus.job_id,
+                )
+                .join(
+                    latest_status_subquery,
+                    and_(
+                        BackendEvaluationJobStatus.job_id
+                        == latest_status_subquery.c.job_id,
+                        BackendEvaluationJobStatus.created_at
+                        == latest_status_subquery.c.max_created_at,
+                    ),
+                )
+                .where(
+                    BackendEvaluationJobStatus.status.in_(
+                        [
+                            EvaluationStatus.COMPLETED,
+                            EvaluationStatus.FAILED,
+                            EvaluationStatus.CANCELLED,
+                            EvaluationStatus.TIMEOUT,
+                        ]
+                    )
+                )
+            )
+
+            # Apply filters if any
+            if filters:
+                for filter_key, filter_value in filters.items():
+                    if filter_key == "job_id":
+                        query = query.where(BackendEvaluationJob.id == filter_value)
+                    elif filter_key == "validator_hotkey":
+                        query = query.where(
+                            BackendEvaluationJobStatus.validator_hotkey == filter_value
+                        )
+
+            query = query.order_by(BackendEvaluationJobStatus.created_at.desc()).limit(
+                limit
+            )
+
+            result = await session.execute(query)
+            rows = result.all()
+
+            job_data = []
+            for job, status in rows:
+                # Use JobCompletedEvent model
+                event = JobCompletedEvent(
+                    job_id=str(job.id),
+                    validator_hotkey=status.validator_hotkey,
+                    status=status.status.value,
+                    detail=status.detail,
+                    result_count=0,  # Could be enhanced to count results
+                )
+                job_data.append(event.model_dump(mode="json"))
+
+            return job_data
+
+        except Exception as e:
+            logger.error(f"Error getting initial job completed data: {str(e)}")
             return []
 
     async def _get_initial_evaluation_data(

--- a/src/backend/service.py
+++ b/src/backend/service.py
@@ -938,6 +938,10 @@ class BackendService:
                 logger.debug(f"Created evaluation job: {eval_job}")
 
                 # Broadcast job created event to clients
+                connected_validator_hotkeys = tuple(
+                    dict.fromkeys(self.validator_connections.values())
+                )
+
                 job_event = JobCreatedEvent(
                     job_id=str(eval_job.id),
                     competition_id=eval_job.competition_id,
@@ -948,6 +952,10 @@ class BackendService:
                     benchmark_name=eval_job.benchmark_name,
                     config=eval_job.config if eval_job.config else {},
                     status=EvaluationStatus.QUEUED,
+                    validator_statuses={
+                        hotkey: EvaluationStatus.QUEUED
+                        for hotkey in connected_validator_hotkeys
+                    },
                 )
                 await event_broadcaster.broadcast_event(
                     EventType.JOB_CREATED, job_event

--- a/src/backend/service.py
+++ b/src/backend/service.py
@@ -401,7 +401,7 @@ class BackendService:
                                 await event_broadcaster.broadcast_event(
                                     EventType.JOB_STATUS_CHANGED,
                                     {
-                                        "job_id": job.id,
+                                        "job_id": str(job.id),
                                         "status": "TIMEOUT",
                                         "detail": "Job marked as timeout due to inactivity",
                                     },

--- a/src/backend/service.py
+++ b/src/backend/service.py
@@ -947,6 +947,7 @@ class BackendService:
                     env_provider=eval_job.env_provider,
                     benchmark_name=eval_job.benchmark_name,
                     config=eval_job.config if eval_job.config else {},
+                    status=EvaluationStatus.QUEUED,
                 )
                 await event_broadcaster.broadcast_event(
                     EventType.JOB_CREATED, job_event

--- a/src/core/messages.py
+++ b/src/core/messages.py
@@ -178,7 +178,7 @@ class EpisodeDataMessage(SQLModel):
     episode_id: int
     env_name: str
     benchmark_name: str
-    total_reward: float
+    final_reward: float
     success: bool
     steps: int
     start_time: datetime

--- a/src/core/messages.py
+++ b/src/core/messages.py
@@ -27,6 +27,7 @@ class MessageType(StrEnum):
     SET_WEIGHTS = "set_weights"
     EPISODE_DATA = "episode_data"
     EPISODE_STEP_DATA = "episode_step_data"
+    JOB_STATUS_UPDATE = "job_status_update"
     ERROR = "error"
 
     # Client-Backend WebSocket messages
@@ -114,6 +115,17 @@ class EvalResultMessage(SQLModel):
     logs: Optional[str] = None
     error: Optional[str] = None
     extra_data: Optional[dict] = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class JobStatusUpdateMessage(SQLModel):
+    """Message for notifying backend about job status changes."""
+
+    message_type: MessageType = MessageType.JOB_STATUS_UPDATE
+    job_id: SnowflakeId
+    validator_hotkey: str
+    status: EvaluationStatus
+    detail: Optional[str] = None
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/src/evaluator/orchestrator.py
+++ b/src/evaluator/orchestrator.py
@@ -33,6 +33,7 @@ QUEUE_MAXSIZE = 100
 # TODO: this might be way too long
 EVAL_TIMEOUT = 3600
 RAY_WAIT_TIMEOUT = 0.1
+MIN_CONCURRENT_JOBS = 4
 
 
 class Orchestrator:
@@ -48,8 +49,15 @@ class Orchestrator:
 
         # Track running jobs for concurrent execution
         self.running_jobs: Dict[str, Dict] = {}  # job_id -> job_info
-        self.max_concurrent_jobs = config.max_concurrent_jobs
+        if config.max_concurrent_jobs < MIN_CONCURRENT_JOBS:
+            logger.warning(
+                "Configured max_concurrent_jobs (%s) below minimum (%s); clamping.",
+                config.max_concurrent_jobs,
+                MIN_CONCURRENT_JOBS,
+            )
+        self.max_concurrent_jobs = max(MIN_CONCURRENT_JOBS, config.max_concurrent_jobs)
         self.job_timeout = config.settings.get("job_timeout_seconds", EVAL_TIMEOUT)
+        self.concurrent_slots = asyncio.Semaphore(self.max_concurrent_jobs)
 
         # Initialize Ray with explicit configuration
         if not ray.is_initialized():
@@ -498,13 +506,32 @@ class Orchestrator:
 
     async def process_job(self, job: Job):
         """Process a job asynchronously without blocking."""
-        job_context = await self.setup_job(job)
-        if job_context:
-            job_id = job_context["job_id"]
-            self.running_jobs[job_id] = job_context
-            logger.info(
-                f"Job {job_id} added to running jobs. Total running: {len(self.running_jobs)}"
+        if self.concurrent_slots.locked():
+            logger.warning(
+                f"Max concurrent jobs ({self.max_concurrent_jobs}) reached. Job {getattr(job, 'id', 'unknown')} waiting for a free slot."
             )
+
+        await self.concurrent_slots.acquire()
+
+        try:
+            job_context = await self.setup_job(job)
+        except Exception as e:
+            logger.error(f"Failed to process job {getattr(job, 'id', 'unknown')}: {e}")
+            self.concurrent_slots.release()
+            return
+
+        if not job_context:
+            logger.warning(
+                f"Setup for job {getattr(job, 'id', 'unknown')} returned no context; releasing slot."
+            )
+            self.concurrent_slots.release()
+            return
+
+        job_id = job_context["job_id"]
+        self.running_jobs[job_id] = job_context
+        logger.info(
+            f"Job {job_id} added to running jobs. Total running: {len(self.running_jobs)}"
+        )
 
     async def monitor_running_jobs(self):
         """Background task to monitor all running jobs."""
@@ -518,12 +545,11 @@ class Orchestrator:
 
                 # Remove completed jobs
                 for job_id in completed_jobs:
-                    # Clear job context before deletion
-                    job_context = self.running_jobs.get(job_id)
-                    if job_context:
+                    job_context = self.running_jobs.pop(job_id, None)
+                    if job_context is not None:
+                        self.concurrent_slots.release()
                         # Clear references to heavy objects
                         job_context.clear()
-                    del self.running_jobs[job_id]
                     logger.info(
                         f"Job {job_id} removed from running jobs. Remaining: {len(self.running_jobs)}"
                     )
@@ -661,16 +687,7 @@ class Orchestrator:
 
         @pgq.entrypoint("add_job")
         async def process(job: Job) -> None:
-            # Check if we can accept more jobs
-            if len(self.running_jobs) >= self.max_concurrent_jobs:
-                logger.warning(
-                    f"Max concurrent jobs ({self.max_concurrent_jobs}) reached. Job {job.id} will be delayed."
-                )
-                # Wait until a slot becomes available
-                while len(self.running_jobs) >= self.max_concurrent_jobs:
-                    await asyncio.sleep(1)
-
-            asyncio.get_event_loop().create_task(self.process_job(job))
+            asyncio.create_task(self.process_job(job))
             logger.info(f"Job {job.id} added to processing queue.")
 
         logger.info(
@@ -689,29 +706,30 @@ class Orchestrator:
         logger.info("Stopping orchestrator...")
         # Clean up all running jobs
         for job_id in list(self.running_jobs.keys()):
-            job_context = self.running_jobs.get(job_id)
-            if job_context:
-                try:
-                    # Clean up queues first
-                    self._cleanup_queues(job_context)
+            job_context = self.running_jobs.pop(job_id, None)
+            if job_context is None:
+                continue
+            try:
+                # Clean up queues first
+                self._cleanup_queues(job_context)
 
-                    cluster = job_context.get("cluster")
-                    worker = job_context.get("worker")
-                    if cluster and worker:
-                        # Try to call cleanup on the worker before killing it
-                        try:
-                            ray.get(worker.cleanup.remote(), timeout=2)
-                        except Exception as e:
-                            logger.warning(
-                                f"Worker cleanup failed during shutdown: {e}"
-                            )
-                        cluster.delete_worker(worker)
-                    submission_id = job_context.get("submission_id")
-                    if submission_id:
-                        containers = Containers()
-                        containers.cleanup_container(submission_id)
-                except Exception as e:
-                    logger.error(f"Error cleaning up job {job_id}: {e}")
+                cluster = job_context.get("cluster")
+                worker = job_context.get("worker")
+                if cluster and worker:
+                    # Try to call cleanup on the worker before killing it
+                    try:
+                        ray.get(worker.cleanup.remote(), timeout=2)
+                    except Exception as e:
+                        logger.warning(f"Worker cleanup failed during shutdown: {e}")
+                    cluster.delete_worker(worker)
+                submission_id = job_context.get("submission_id")
+                if submission_id:
+                    containers = Containers()
+                    containers.cleanup_container(submission_id)
+            except Exception as e:
+                logger.error(f"Error cleaning up job {job_id}: {e}")
+            finally:
+                self.concurrent_slots.release()
 
         self.running_jobs.clear()
 

--- a/src/evaluator/rollout/envs.py
+++ b/src/evaluator/rollout/envs.py
@@ -77,6 +77,8 @@ class EpisodeResult:
     info: Dict[str, Any] = field(default_factory=dict)
 
 
+# TODO: add task name from i.e. task_spec to the EnvResult?
+# this would be useful for identifying which task within a multi-task benchmark/env
 @dataclass
 class EnvResult:
     """Aggregated results from all episodes of an environment in a benchmark."""

--- a/src/evaluator/rollout/episode_logger.py
+++ b/src/evaluator/rollout/episode_logger.py
@@ -206,14 +206,14 @@ class EpisodeLogger:
 
     async def end_episode(
         self,
-        total_reward: float,
+        final_reward: float,
         success: bool,
         extra_metrics: Optional[Dict[str, Any]] = None,
     ) -> None:
         """End the current episode and save data.
 
         Args:
-            total_reward: Total reward for the episode
+            final_reward: Final reward for the episode
             success: Whether the episode was successful
             extra_metrics: Additional metrics to store
         """
@@ -232,7 +232,7 @@ class EpisodeLogger:
                 "episode_id": self._current_episode_id,
                 "env_name": self.env_name,
                 "benchmark_name": self.benchmark_name,
-                "total_reward": total_reward,
+                "final_reward": final_reward,
                 "success": success,
                 "steps": len(self._current_episode_steps),
                 "start_time": self._current_episode_start,

--- a/src/evaluator/tests/test_rpc_rollout_integration.py
+++ b/src/evaluator/tests/test_rpc_rollout_integration.py
@@ -90,7 +90,7 @@ class RealRolloutWorker:
         observation, info = env.reset()
         done = False
         step_count = 0
-        final_reward = 0.0
+        cum_reward = 0.0
 
         episode_start = time.time()
 
@@ -108,7 +108,8 @@ class RealRolloutWorker:
                 # Step environment
                 observation, reward, terminated, truncated, info = env.step(action)
 
-                final_reward = float(reward)
+                reward_value = float(reward)
+                cum_reward += reward_value
                 step_count += 1
                 done = terminated or truncated
 
@@ -122,14 +123,14 @@ class RealRolloutWorker:
 
         logger.info(
             f"Episode {episode_id} completed: {step_count} steps, "
-            f"reward={final_reward:.2f}, duration={episode_duration:.2f}s"
+            f"cum_reward={cum_reward:.2f}, duration={episode_duration:.2f}s"
         )
 
         return {
             "episode_id": episode_id,
             "env_spec": env_spec,
             "steps": step_count,
-            "reward": final_reward,
+            "reward": cum_reward,
             "duration": episode_duration,
             "success": info.get("success", 0.0) if info else 0.0,
         }

--- a/src/evaluator/tests/test_rpc_rollout_integration.py
+++ b/src/evaluator/tests/test_rpc_rollout_integration.py
@@ -90,7 +90,7 @@ class RealRolloutWorker:
         observation, info = env.reset()
         done = False
         step_count = 0
-        total_reward = 0.0
+        final_reward = 0.0
 
         episode_start = time.time()
 
@@ -108,7 +108,7 @@ class RealRolloutWorker:
                 # Step environment
                 observation, reward, terminated, truncated, info = env.step(action)
 
-                total_reward += float(reward)
+                final_reward = float(reward)
                 step_count += 1
                 done = terminated or truncated
 
@@ -122,14 +122,14 @@ class RealRolloutWorker:
 
         logger.info(
             f"Episode {episode_id} completed: {step_count} steps, "
-            f"reward={total_reward:.2f}, duration={episode_duration:.2f}s"
+            f"reward={final_reward:.2f}, duration={episode_duration:.2f}s"
         )
 
         return {
             "episode_id": episode_id,
             "env_spec": env_spec,
             "steps": step_count,
-            "reward": total_reward,
+            "reward": final_reward,
             "duration": episode_duration,
             "success": info.get("success", 0.0) if info else 0.0,
         }


### PR DESCRIPTION
Backend:
- add completed_jobs and failed_jobs fields to StatsUpdatedEvent
- broadcast stats updates on validator connect/disconnect events
- add submission received event broadcasting
- split job event initial data handlers (created/status/completed)
- enable initial data for VALIDATOR_CONNECTED subscriptions
- fix job_id types from str to int in event models
- broadcast validator disconnected events on heartbeat timeout
- send snowflake ids as strings in responses because javascript is retarded and is limited to 53 bits >:(

Orchestrator:
- enforce concurrency slots in orchestrator
- clamp configured limit and log when clamped
- centralize semaphore acquire/release around job lifecycle
- fix reward accounting
- set `done` to true during episode when `"success"` is 1
- mark evaluation jobs running when orchestrator starts work