### PR TITLE
feat: overhaul metaworld rollout observation plumbing

### DIFF
--- a/src/evaluator/rpc/agent.capnp
+++ b/src/evaluator/rpc/agent.capnp
@@ -2,7 +2,7 @@
 
 interface Agent {
   ping @0 (message :Text) -> (response :Text);
-  act  @1 (obs :Tensor) -> (action :Tensor);
+  act  @1 (obs :Observation) -> (action :Tensor);
   reset @2 ();
 }
 
@@ -10,4 +10,13 @@ struct Tensor {
   data  @0 :Data;
   shape @1 :List(Int32);
   dtype @2 :Text;
+}
+
+struct ObservationEntry {
+  key @0 :Text;
+  tensor @1 :Tensor;
+}
+
+struct Observation {
+  entries @0 :List(ObservationEntry);
 }

--- a/src/evaluator/rpc/rpc_process.py
+++ b/src/evaluator/rpc/rpc_process.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Any, Optional
 
 import capnp
-import numpy as np
 import torch
 from ray.util.queue import Queue
 from snowflake import SnowflakeGenerator
@@ -53,10 +52,8 @@ class RPCRequest:
         )
 
     @classmethod
-    def create_act(
-        cls, obs: np.ndarray, timeout: float = DEFAULT_RPC_TIMEOUT
-    ) -> "RPCRequest":
-        """Create an act request with observation"""
+    def create_act(cls, obs: Any, timeout: float = DEFAULT_RPC_TIMEOUT) -> "RPCRequest":
+        """Create an act request with observation payload (array or dict)."""
         return cls(
             method=RPCMethod.ACT,
             request_id=str(next(SnowflakeGenerator(42))),


### PR DESCRIPTION
- reshape Metaworld wrappers so rollouts emit keyed dict observations with camera images
- push structured observation tensors (with entry metadata) end-to-end through the RPC request/response path
- refresh rollout worker helpers to normalise payloads for agents and reuse decoded images for episode logging